### PR TITLE
Fixing deployment details

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
 
 install:
   - make install
+
 script:
   - make test
   - make build
@@ -15,6 +16,7 @@ deploy:
   github_token: $GITHUB_TOKEN # Set in the settings page of your repository, as a secure variable
   verbose: true
   on:
+    repo: statium-io/statium-webapp
     branch: master
 
 cache:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Statium Webapp
 
-[![Build Status](https://travis-ci.org/dirtyhenry/statium-webapp.svg?branch=master)](https://travis-ci.org/dirtyhenry/statium-webapp)
+[![Build Status](https://travis-ci.org/statium-io/statium-webapp.svg?branch=master)](https://travis-ci.org/statium-io/statium-webapp)
 
 Statium Webapp is a web calendar for the football/soccer fans.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "statium-webapp",
   "version": "0.1.0",
   "private": true,
-  "homepage": "http://statium-io.github.io/statium-webapp",
+  "homepage": "https://statium-io.github.io/statium-webapp",
   "dependencies": {
     "@types/jest": "24.0.12",
     "@types/node": "11.13.8",


### PR DESCRIPTION
This PR completes #2 with some details and small fixes: 

* Don't let the CI try to deploy from forks; 
* Use the main repo CI status in the README badge, not the forks;
* Use `https` in the homepage.